### PR TITLE
add Google Analytics to the site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,3 +20,5 @@ github:
   organization: opencontrol
   repository: atos
   default_branch: master
+
+google_analytics_ua: UA-141012673-1


### PR DESCRIPTION
Turned off the promotional settings:

![Screen Shot 2019-05-29 at 12 39 20 AM](https://user-images.githubusercontent.com/86842/58529792-45fad280-81aa-11e9-9e65-371eb96e612e.png)

I'm interested in adding it because I'm curious:

- If people are using the site
- Where they are coming from
- What content gets the most attention

That said, I would understand an argument of "we don't want to track OpenControl users." Will merge and add others to the analytics account unless anyone says they feel strongly they don't want it.

## Follow-up tasks

- [x] Add others to the Google Analytics account (and make public, where possible)
- [x] Add to [website](https://github.com/opencontrol/website)
- [x] Add OpenControl to [Search Console](https://search.google.com/search-console)